### PR TITLE
Check LE advertising data length before caching advertising records

### DIFF
--- a/stack/btm/btm_ble_gap.c
+++ b/stack/btm/btm_ble_gap.c
@@ -26,6 +26,8 @@
 #include <stdio.h>
 #include <stddef.h>
 
+#include <log/log.h>
+
 #include "bt_types.h"
 #include "bt_utils.h"
 #include "btm_int.h"
@@ -2264,7 +2266,7 @@ static void btm_ble_parse_adv_data(tBTM_INQ_INFO *p_info, UINT8 *p_data,
 ** Returns          void
 **
 *******************************************************************************/
-void btm_ble_cache_adv_data(tBTM_INQ_RESULTS *p_cur, UINT8 data_len, UINT8 *p, UINT8 evt_type)
+BOOLEAN btm_ble_cache_adv_data(tBTM_INQ_RESULTS *p_cur, UINT8 data_len, UINT8 *p, UINT8 evt_type)
 {
     tBTM_BLE_INQ_CB     *p_le_inq_cb = &btm_cb.ble_ctr_cb.inq_var;
     UINT8 *p_cache;
@@ -2284,8 +2286,16 @@ void btm_ble_cache_adv_data(tBTM_INQ_RESULTS *p_cur, UINT8 data_len, UINT8 *p, U
         STREAM_TO_UINT8(length, p);
         while ( length && ((p_le_inq_cb->adv_len + length + 1) <= BTM_BLE_CACHE_ADV_DATA_MAX))
         {
+            /* adv record size must be smaller than the total adv data size */
+            if ((length + 1) > data_len) {
+                BTM_TRACE_ERROR("BTM - got incorrect LE advertising data");
+                android_errorWriteLog(0x534e4554, "33899337");
+                return FALSE;
+            }
             /* copy from the length byte & data into cache */
             memcpy(p_cache, p-1, length+1);
+            /* reduce the total data size by size of data copied */
+            data_len -= length + 1;
             /* advance the cache pointer past data */
             p_cache += length+1;
             /* increment cache length */
@@ -2295,6 +2305,7 @@ void btm_ble_cache_adv_data(tBTM_INQ_RESULTS *p_cur, UINT8 data_len, UINT8 *p, U
             STREAM_TO_UINT8(length, p);
         }
     }
+    return TRUE;
 
     /* parse service UUID from adv packet and save it in inq db eir_uuid */
     /* TODO */
@@ -2519,7 +2530,9 @@ BOOLEAN btm_ble_update_inq_result(tINQ_DB_ENT *p_i, UINT8 addr_type, UINT8 evt_t
         BTM_TRACE_WARNING("EIR data too long %d. discard", data_len);
         return FALSE;
     }
-    btm_ble_cache_adv_data(p_cur, data_len, p, evt_type);
+    if (!btm_ble_cache_adv_data(p_cur, data_len, p, evt_type)) {
+        return FALSE;
+    }
 
     p1 = (p + data_len);
     STREAM_TO_UINT8 (rssi, p1);


### PR DESCRIPTION
Bug: 33899337
Test: make, receive LE advertising
AOSP-Change-Id: I06b249ac5cabdef64528deda07b8bae749e1d2fd
(cherry picked from commit d57adbc350fdee4f27b82c9e39a14bd745d92320)
(cherry picked from commit 1bef3546a6cb6f05739c10825dab9eb3362892f6)

CVE-2017-0646

Change-Id: I02f408e5fe354434aa39a2c7f1a17b67e1e38193